### PR TITLE
fix: ensure that Job owner is actually a CronJob before appending it

### DIFF
--- a/main.go
+++ b/main.go
@@ -273,9 +273,8 @@ func printResources(namespace corev1.Namespace, clientset *kubernetes.Clientset,
 						continue
 					}
 
-					// check if the job has an owner
-					// If it does then it's part of a CronJob
-					if len(job.ObjectMeta.OwnerReferences) == 0 {
+					// check if the job has an owner, and that it is of kind `CronJob`
+					if len(job.ObjectMeta.OwnerReferences) == 0 || job.ObjectMeta.OwnerReferences[0].Kind != "CronJob" {
 						if _, ok := nsJobs[job.Name]; !ok {
 							nsJobs[job.Name] = job
 						}


### PR DESCRIPTION
this additional check ensures that the `Job` owner is really of kind `CronJob`

previously this check would just assume it was a `CronJob`, if the `OwnerReferences` list was non-empty.

This caused problems for us when running `dds`, as we have `Job` resources which are not created by a `CronJob`, but in fact are "owned" by a CRD and created by a custom operator.

`dds` would throw errors like this when it encountered such a `Job`:
```
❯ kubectl dds --namespace redacted
error: cronjobs.batch "redacted-config" not found
```

an extract of the manifest for a `Job` like this:
```
apiVersion: batch/v1
kind: Job
metadata:
  name: redacted-91231432ac
  namespace: redacted
  ...
  ownerReferences:
    - apiVersion: redacted.net/v1alpha1
      kind: RedactedConfig
      name: redacted-config
      ...
```